### PR TITLE
Update VOLTTRON-Central-Demo.rst

### DIFF
--- a/docs/source/devguides/walkthroughs/VOLTTRON-Central-Demo.rst
+++ b/docs/source/devguides/walkthroughs/VOLTTRON-Central-Demo.rst
@@ -157,7 +157,7 @@ different.
          Is this an instance of volttron central? [N]: 
          Will this instance be controlled by volttron central? [Y]: y
          Configuring /home/user/volttron/services/core/VolttronCentralPlatform.
-         What is the name of this instance? [volttron1]: 
+         What is the name of this instance? [volttron1]: volttron2
          What is the hostname for volttron central? [https://volttron-pc]: 
          What is the port for volttron central? [8443]: 
          Should the agent autostart? [N]: y


### PR DESCRIPTION
Slight refinement in the example.  We DO want the instance name of the 2nd instance to be different than the 1st instance name (otherwise it wont show up at all as a platform in VOLTTRON Central).  Hence need to show in the example that we set the 2nd instance name to 'volttron2'.

# Description

Minor fix to the example provided